### PR TITLE
fix all deprecation warnings based off terraform 0.12.29

### DIFF
--- a/examples/demo/variables.tf
+++ b/examples/demo/variables.tf
@@ -1,6 +1,6 @@
 variable "name" {
   description = "The name of the rendered policy file (no file extension)."
-  type        = "string"
+  type        = string
 }
 
 variable "minimize" {
@@ -11,66 +11,66 @@ variable "minimize" {
 
 variable "read_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs READ access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "write_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs WRITE access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "list_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs LIST access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "tagging_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs TAGGING access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "permissions_management_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs PERMISSIONS MANAGEMENT access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_single_actions" {
   description = "Individual actions that do not support resource constraints. For example, s3:ListAllMyBuckets"
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_read_service" {
   description = "To generate a list of AWS service actions that (1) are at the READ access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_write_service" {
   description = "To generate a list of AWS service actions that (1) are at the WRITE access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_list_service" {
   description = "To generate a list of AWS service actions that (1) are at the LIST access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_tagging_service" {
   description = "To generate a list of AWS service actions that (1) are at the TAGGING access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_permissions_management_service" {
   description = "To generate a list of AWS service actions that (1) are at the PERMISSIONS MANAGEMENT access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }

--- a/provider.tf
+++ b/provider.tf
@@ -14,3 +14,8 @@ provider "template" {
 provider "local" {
   version = "~> 1.3"
 }
+
+provider "null" {
+  version = "~> 2.1"
+}
+

--- a/ps-template/main.tf
+++ b/ps-template/main.tf
@@ -27,6 +27,7 @@ locals {
 resource "null_resource" "command" {
   # Just creating a unique string so that when the long unique string changes, the command will be run again.
   triggers = {
+    file = "${var.name}.json"
     policy_sentry_template = join(",", concat(
       var.read_access_level,
       var.write_access_level,
@@ -46,13 +47,13 @@ resource "null_resource" "command" {
 
   provisioner "local-exec" {
     # If the json file exists from a previous run, delete it first.
-    # command = "[ ! -e ${var.name}.json ] || rm ${var.name}.json && echo '${local.rendered_template}' | policy_sentry write-policy ${local.minimize} > ${var.name}.json"
+    # command = "[ ! -e ${self.triggers.file} ] || rm ${self.triggers.file} && echo '${local.rendered_template}' | policy_sentry write-policy ${local.minimize} > ${self.triggers.file}"
     # Render the template as JSON and ingest via stdin
-    command = "echo '${local.rendered_template}' | policy_sentry write-policy ${local.minimize} > ${var.name}.json"
+    command = "echo '${local.rendered_template}' | policy_sentry write-policy ${local.minimize} > ${self.triggers.file}"
   }
 
   provisioner "local-exec" {
-    command = "[ ! -e ${var.name}.json ] || rm ${var.name}.json"
-    when    = "destroy"
+    command = "[ ! -e ${self.triggers.file} ] || rm ${self.triggers.file}"
+    when    = destroy
   }
 }

--- a/ps-template/variables.tf
+++ b/ps-template/variables.tf
@@ -1,6 +1,6 @@
 variable "name" {
   description = "The name of the rendered policy file (no file extension)."
-  type        = "string"
+  type        = string
 }
 
 variable "minimize" {
@@ -11,66 +11,66 @@ variable "minimize" {
 
 variable "read_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs READ access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "write_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs WRITE access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "list_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs LIST access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "tagging_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs TAGGING access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "permissions_management_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs PERMISSIONS MANAGEMENT access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_single_actions" {
   description = "Individual actions that do not support resource constraints. For example, s3:ListAllMyBuckets"
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_read_service" {
   description = "To generate a list of AWS service actions that (1) are at the READ access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_write_service" {
   description = "To generate a list of AWS service actions that (1) are at the WRITE access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_list_service" {
   description = "To generate a list of AWS service actions that (1) are at the LIST access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_tagging_service" {
   description = "To generate a list of AWS service actions that (1) are at the TAGGING access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_permissions_management_service" {
   description = "To generate a list of AWS service actions that (1) are at the PERMISSIONS MANAGEMENT access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "name" {
   description = "The name of the rendered policy file (no file extension)."
-  type        = "string"
+  type        = string
 }
 
 variable "description" {
@@ -27,66 +27,66 @@ variable "minimize" {
 
 variable "read_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs READ access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "write_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs WRITE access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "list_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs LIST access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "tagging_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs TAGGING access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "permissions_management_access_level" {
   description = "Provide a list of Amazon Resource Names (ARNs) that your role needs PERMISSIONS MANAGEMENT access to."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_single_actions" {
   description = "Individual actions that do not support resource constraints. For example, s3:ListAllMyBuckets"
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_read_service" {
   description = "To generate a list of AWS service actions that (1) are at the READ access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_write_service" {
   description = "To generate a list of AWS service actions that (1) are at the WRITE access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_list_service" {
   description = "To generate a list of AWS service actions that (1) are at the LIST access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_tagging_service" {
   description = "To generate a list of AWS service actions that (1) are at the TAGGING access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }
 
 variable "wildcard_only_permissions_management_service" {
   description = "To generate a list of AWS service actions that (1) are at the PERMISSIONS MANAGEMENT access level and (2) do not support resource constraints, list the service prefix here."
-  type        = "list"
+  type        = list
   default     = [""]
 }


### PR DESCRIPTION
- types are no longer quoted
- reserved keywords are no longer quoted
- null_resources should only reference self
- added provider constraint for null